### PR TITLE
Fixed functions as callable

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -4,17 +4,17 @@ namespace Spl\Scalars;
 class Arrays {
 
   public function chunk($size) {
-    $this->verifyInteger($size, "chunk()");
+    $this->verifyInteger($size, "chunk");
     return array_chunk($this, $size);
   }
 
   public function column($key) {
-    $this->verifyString($key, "column()");
+    $this->verifyString($key, "column");
     return array_column($this, $key);
   }
 
   public function combine($arrayVals) {
-    $this->verifyArray($arrayVals, "combine()");
+    $this->verifyArray($arrayVals, "combine");
     return array_combine($this,$arrayVals);
   }
 
@@ -27,7 +27,7 @@ class Arrays {
   }
 
   public function diff($array) {
-    $this->verifyArray($array, "diff()");
+    $this->verifyArray($array, "diff");
     return array_diff($this, $array);
   }
 
@@ -41,7 +41,7 @@ class Arrays {
   }
 
   public function hasKey($key) {
-    $this->verifyString($key, "hasKey()");
+    $this->verifyString($key, "hasKey");
     return array_key_exists($key, $this);
   }
 
@@ -67,7 +67,7 @@ class Arrays {
   }
 
   public function merge($array) {
-    $this->verifyArray($array, "merge()");
+    $this->verifyArray($array, "merge");
     return array_merge($this, $array);
   }
 


### PR DESCRIPTION
When passing a function as a callable, there is no need for `()`.

Example: `strlen` instead of `strlen()`.
