### PR TITLE
added toFixed and stubbed toPrecision, added test coverage.

### DIFF
--- a/src/FloatHandler.php
+++ b/src/FloatHandler.php
@@ -14,4 +14,19 @@ class FloatHandler extends NumberHandler
         return round($this, $precision, $mode);
     }
 
+    //Stub
+    public function toPrecision ($int = null) {
+        if (!$int === null) {
+            return $this->toString();
+        }
+        return $this->toString();
+    }
+
+    public function toFixed ($int = null) {
+        if ($int === null) {
+            return $this->toString();
+        }
+        return round($this, $int)->toString();
+    }
+
 }

--- a/src/NumberHandler.php
+++ b/src/NumberHandler.php
@@ -55,7 +55,7 @@ class NumberHandler
 
     public function toFloat()
     {
-        return float($this);
+        return (float)$this;
     }
 
     public function toInt()
@@ -71,7 +71,7 @@ class NumberHandler
 
     public function toString()
     {
-        return string($this);
+        return (string)$this;
     }
 
     protected function verifyNumeric($input = null, $methodName = "")

--- a/tests/FloatHandlerTest.php
+++ b/tests/FloatHandlerTest.php
@@ -17,4 +17,38 @@ class FloatHandlerTest extends \PHPUnit_Framework_TestCase {
 
   }
 
+  public function test_toFixed() {
+    $f = 5.123456;
+    $this->assertEquals($f->toFixed(), "5.123456");
+    $this->assertEquals($f->toFixed(1), "5.1");
+    $this->assertEquals($f->toFixed(2), "5.12");
+    $this->assertEquals($f->toFixed(3), "5.123");
+    $this->assertEquals($f->toFixed(4), "5.1235");
+    $this->assertEquals($f->toFixed(5), "5.12346");
+    $this->assertEquals($f->toFixed(6), "5.123456");
+    $this->assertEquals($f->toFixed(10), "5.1234560000");
+  }
+
+  public function test_toPrecision() {
+    $f = 5.123456;
+    $this->assertEquals($f->toPrecision(), "5.123456");
+    $this->assertEquals($f->toPrecision(5), "5.1235");
+    $this->assertEquals($f->toPrecision(2), "5.1");
+    $this->assertEquals($f->toPrecision(1), "5");
+
+    $f = 10.123;
+    $this->assertEquals($f->toPrecision(), "10.123");
+    $this->assertEquals($f->toPrecision(2), "10");
+    $this->assertEquals($f->toPrecision(3), "10.1");
+    $this->assertEquals($f->toPrecision(1), "1e1");
+
+    $f = 10234.4;
+    $this->assertEquals($f->toPrecision(), "10234.4");
+    $this->assertEquals($f->toPrecision(6), "10234.4");
+    $this->assertEquals($f->toPrecision(5), "10234");
+    $this->assertEquals($f->toPrecision(4), "1023e1");
+    $this->assertEquals($f->toPrecision(3), "102e2");
+    $this->assertEquals($f->toPrecision(2), "10e3");
+    $this->assertEquals($f->toPrecision(1), "1e4");
+  }
 }


### PR DESCRIPTION
I'm not sure about toPrecision. It is a helpful method when you need a numeric value to fit into a specified character width for the presentation layer, but exponential returns are hairy in PHP since there is no native exponent representation.
